### PR TITLE
WebBrowser and RibbonBar control

### DIFF
--- a/pfcmain/pfc_u_rbb.sru
+++ b/pfcmain/pfc_u_rbb.sru
@@ -1,0 +1,160 @@
+HA$PBExportHeader$pfc_u_rbb.sru
+$PBExportComments$PFC RibbonBar class
+forward
+global type pfc_u_rbb from ribbonbar
+end type
+end forward
+
+global type pfc_u_rbb from ribbonbar
+integer width = 411
+integer height = 460
+long backcolor = 15132390
+integer textsize = -8
+integer weight = 400
+fontcharset fontcharset = ansi!
+fontpitch fontpitch = variable!
+fontfamily fontfamily = swiss!
+string facename = "Arial"
+end type
+global pfc_u_rbb pfc_u_rbb
+
+type variables
+Protected:
+boolean		ib_IsObsolete
+end variables
+forward prototypes
+public function integer of_getparentwindow (ref window aw_parent)
+protected function integer of_messagebox (string as_id, string as_title, string as_text, icon ae_icon, button ae_button, integer ai_default)
+end prototypes
+
+public function integer of_getparentwindow (ref window aw_parent);//////////////////////////////////////////////////////////////////////////////
+//
+//	Function:  of_GetParentWindow
+//
+//	Access:  public
+//
+//	Arguments:
+//	aw_parent   The Parent window for this object (passed by reference).
+//	   If a parent window is not found, aw_parent is NULL
+//
+//	Returns:  integer
+//	 1 = success
+//	-1 = error
+//
+//	Description:	 Calculates the parent window of a window object
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Revision History
+//
+//	Version
+//	2019 R2   Initial version
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+/*
+ * Open Source PowerBuilder Foundation Class Libraries
+ *
+ * Copyright (c) 2004-2017, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted in accordance with the MIT License
+
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals and was originally based on software copyright (c) 
+ * 1996-2004 Sybase, Inc. http://www.sybase.com.  For more
+ * information on the Open Source PowerBuilder Foundation Class
+ * Libraries see https://github.com/OpenSourcePFCLibraries
+*/
+//
+//////////////////////////////////////////////////////////////////////////////
+
+powerobject	lpo_parent
+
+lpo_parent = this.GetParent()
+
+// Loop getting the parent of the object until it is of type window!
+do while IsValid (lpo_parent) 
+	if lpo_parent.TypeOf() <> window! then
+		lpo_parent = lpo_parent.GetParent()
+	else
+		exit
+	end if
+loop
+
+if IsNull(lpo_parent) Or not IsValid (lpo_parent) then
+	setnull(aw_parent)	
+	return -1
+end If
+
+aw_parent = lpo_parent
+return 1
+
+end function
+
+protected function integer of_messagebox (string as_id, string as_title, string as_text, icon ae_icon, button ae_button, integer ai_default);//////////////////////////////////////////////////////////////////////////////
+//
+//	Function:  			of_MessageBox
+//
+//	Access:  			protected
+//
+//	Arguments:
+//	as_id			An ID for the Message.
+//	as_title  	Text for title bar
+//	as_text		Text for the actual message.
+//	ae_icon 		The icon you want to display on the MessageBox.
+//	ae_button	Set of CommandButtons you want to display on the MessageBox.
+//	ai_default  The default button.
+//
+//	Returns:  integer
+//	Return value of the MessageBox.
+//
+//	Description:
+//	Display a PowerScript MessageBox.  
+//	Allow PFC MessageBoxes to be manipulated prior to their actual display.
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Revision History
+//
+//	Version
+//	2019 R2   Initial version
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+/*
+ * Open Source PowerBuilder Foundation Class Libraries
+ *
+ * Copyright (c) 2004-2017, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted in accordance with the MIT License
+
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals and was originally based on software copyright (c) 
+ * 1996-2004 Sybase, Inc. http://www.sybase.com.  For more
+ * information on the Open Source PowerBuilder Foundation Class
+ * Libraries see https://github.com/OpenSourcePFCLibraries
+*/
+//
+//////////////////////////////////////////////////////////////////////////////
+
+Return MessageBox(as_title, as_text, ae_icon, ae_button, ai_default)
+end function
+
+on pfc_u_rbb.create
+end on
+
+on pfc_u_rbb.destroy
+end on
+

--- a/pfcmain/pfc_u_wb.sru
+++ b/pfcmain/pfc_u_wb.sru
@@ -1,0 +1,208 @@
+HA$PBExportHeader$pfc_u_wb.sru
+$PBExportComments$PFC WebBrowser class
+forward
+global type pfc_u_wb from webbrowser
+end type
+end forward
+
+global type pfc_u_wb from webbrowser
+integer width = 343
+integer height = 352
+end type
+global pfc_u_wb pfc_u_wb
+
+type variables
+Protected:
+boolean		ib_IsObsolete
+end variables
+forward prototypes
+public function integer of_getparentwindow (ref window aw_parent)
+protected function integer of_messagebox (string as_id, string as_title, string as_text, icon ae_icon, button ae_button, integer ai_default)
+end prototypes
+
+public function integer of_getparentwindow (ref window aw_parent);//////////////////////////////////////////////////////////////////////////////
+//
+//	Function:  of_GetParentWindow
+//
+//	Access:  public
+//
+//	Arguments:
+//	aw_parent   The Parent window for this object (passed by reference).
+//	   If a parent window is not found, aw_parent is NULL
+//
+//	Returns:  integer
+//	 1 = success
+//	-1 = error
+//
+//	Description:	 Calculates the parent window of a window object
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Revision History
+//
+//	Version
+//	2019 R2   Initial version
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+/*
+ * Open Source PowerBuilder Foundation Class Libraries
+ *
+ * Copyright (c) 2004-2017, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted in accordance with the MIT License
+
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals and was originally based on software copyright (c) 
+ * 1996-2004 Sybase, Inc. http://www.sybase.com.  For more
+ * information on the Open Source PowerBuilder Foundation Class
+ * Libraries see https://github.com/OpenSourcePFCLibraries
+*/
+//
+//////////////////////////////////////////////////////////////////////////////
+
+powerobject	lpo_parent
+
+lpo_parent = this.GetParent()
+
+// Loop getting the parent of the object until it is of type window!
+do while IsValid (lpo_parent) 
+	if lpo_parent.TypeOf() <> window! then
+		lpo_parent = lpo_parent.GetParent()
+	else
+		exit
+	end if
+loop
+
+if IsNull(lpo_parent) Or not IsValid (lpo_parent) then
+	setnull(aw_parent)	
+	return -1
+end If
+
+aw_parent = lpo_parent
+return 1
+
+end function
+
+protected function integer of_messagebox (string as_id, string as_title, string as_text, icon ae_icon, button ae_button, integer ai_default);//////////////////////////////////////////////////////////////////////////////
+//
+//	Function:  			of_MessageBox
+//
+//	Access:  			protected
+//
+//	Arguments:
+//	as_id			An ID for the Message.
+//	as_title  	Text for title bar
+//	as_text		Text for the actual message.
+//	ae_icon 		The icon you want to display on the MessageBox.
+//	ae_button	Set of CommandButtons you want to display on the MessageBox.
+//	ai_default  The default button.
+//
+//	Returns:  integer
+//	Return value of the MessageBox.
+//
+//	Description:
+//	Display a PowerScript MessageBox.  
+//	Allow PFC MessageBoxes to be manipulated prior to their actual display.
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Revision History
+//
+//	Version
+//	2019 R2   Initial version
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+/*
+ * Open Source PowerBuilder Foundation Class Libraries
+ *
+ * Copyright (c) 2004-2017, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted in accordance with the MIT License
+
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals and was originally based on software copyright (c) 
+ * 1996-2004 Sybase, Inc. http://www.sybase.com.  For more
+ * information on the Open Source PowerBuilder Foundation Class
+ * Libraries see https://github.com/OpenSourcePFCLibraries
+*/
+//
+//////////////////////////////////////////////////////////////////////////////
+
+Return MessageBox(as_title, as_text, ae_icon, ae_button, ai_default)
+end function
+
+on pfc_u_wb.create
+end on
+
+on pfc_u_wb.destroy
+end on
+
+event getfocus;//////////////////////////////////////////////////////////////////////////////
+//
+//	Event:  			getfocus
+//
+//	(Arguments:		None)
+//
+//	(Returns:  		None)
+//
+//	Description:	If appropriate, notify the parent window that this
+//						control got focus.
+//
+//////////////////////////////////////////////////////////////////////////////
+//	
+//	Revision History
+//
+//	Version
+//	2019 R2   Initial version
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+/*
+ * Open Source PowerBuilder Foundation Class Libraries
+ *
+ * Copyright (c) 2004-2017, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted in accordance with the MIT License
+
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals and was originally based on software copyright (c) 
+ * 1996-2004 Sybase, Inc. http://www.sybase.com.  For more
+ * information on the Open Source PowerBuilder Foundation Class
+ * Libraries see https://github.com/OpenSourcePFCLibraries
+*/
+//
+//////////////////////////////////////////////////////////////////////////////
+
+window 	lw_parent
+
+//Check for microhelp requirements.
+If gnv_app.of_GetMicrohelp() Then
+	//Notify the parent.
+	of_GetParentWindow(lw_parent)
+	If IsValid(lw_parent) Then
+		lw_parent.Dynamic Event pfc_ControlGotFocus (this)
+	End If
+End If
+
+end event
+

--- a/pfcmain/pfcmain.pbg
+++ b/pfcmain/pfcmain.pbg
@@ -81,4 +81,6 @@ Save Format v3.0(19990112)
  "pfcmain\\pfc_u_progressbar.sru" "pfcmain\\pfcmain.pbl";
  "pfcmain\\pfc_n_dda.sru" "pfcmain\\pfcmain.pbl";
  "pfcmain\\pfc_u_calendar.sru" "pfcmain\\pfcmain.pbl";
+ "pfcmain\\pfc_u_rbb.sru" "pfcmain\\pfcmain.pbl";
+ "pfcmain\\pfc_u_wb.sru" "pfcmain\\pfcmain.pbl";
 @end;

--- a/pfemain/pfemain.pbg
+++ b/pfemain/pfemain.pbg
@@ -76,4 +76,6 @@ Save Format v3.0(19990112)
  "pfemain\\u_tvs.sru" "pfemain\\pfemain.pbl";
  "pfemain\\u_st.sru" "pfemain\\pfemain.pbl";
  "pfemain\\u_tv.sru" "pfemain\\pfemain.pbl";
+ "pfemain\\u_rbb.sru" "pfemain\\pfemain.pbl";
+ "pfemain\\u_wb.sru" "pfemain\\pfemain.pbl";
 @end;

--- a/pfemain/u_rbb.sru
+++ b/pfemain/u_rbb.sru
@@ -1,0 +1,19 @@
+HA$PBExportHeader$u_rbb.sru
+$PBExportComments$Extension RibbonBar class
+forward
+global type u_rbb from pfc_u_rbb
+end type
+end forward
+
+global type u_rbb from pfc_u_rbb
+end type
+global u_rbb u_rbb
+
+on u_rbb.create
+call super::create
+end on
+
+on u_rbb.destroy
+call super::destroy
+end on
+

--- a/pfemain/u_wb.sru
+++ b/pfemain/u_wb.sru
@@ -1,0 +1,19 @@
+HA$PBExportHeader$u_wb.sru
+$PBExportComments$Extension WebBrowser class
+forward
+global type u_wb from pfc_u_wb
+end type
+end forward
+
+global type u_wb from pfc_u_wb
+end type
+global u_wb u_wb
+
+on u_wb.create
+call super::create
+end on
+
+on u_wb.destroy
+call super::destroy
+end on
+

--- a/ws_objects/pfcmain/pfcmain.pbl.src/pfc_u_rbb.sru
+++ b/ws_objects/pfcmain/pfcmain.pbl.src/pfc_u_rbb.sru
@@ -1,0 +1,160 @@
+﻿$PBExportHeader$pfc_u_rbb.sru
+$PBExportComments$PFC RibbonBar class
+forward
+global type pfc_u_rbb from ribbonbar
+end type
+end forward
+
+global type pfc_u_rbb from ribbonbar
+integer width = 411
+integer height = 460
+long backcolor = 15132390
+integer textsize = -8
+integer weight = 400
+fontcharset fontcharset = ansi!
+fontpitch fontpitch = variable!
+fontfamily fontfamily = swiss!
+string facename = "Arial"
+end type
+global pfc_u_rbb pfc_u_rbb
+
+type variables
+Protected:
+boolean		ib_IsObsolete
+end variables
+forward prototypes
+public function integer of_getparentwindow (ref window aw_parent)
+protected function integer of_messagebox (string as_id, string as_title, string as_text, icon ae_icon, button ae_button, integer ai_default)
+end prototypes
+
+public function integer of_getparentwindow (ref window aw_parent);//////////////////////////////////////////////////////////////////////////////
+//
+//	Function:  of_GetParentWindow
+//
+//	Access:  public
+//
+//	Arguments:
+//	aw_parent   The Parent window for this object (passed by reference).
+//	   If a parent window is not found, aw_parent is NULL
+//
+//	Returns:  integer
+//	 1 = success
+//	-1 = error
+//
+//	Description:	 Calculates the parent window of a window object
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Revision History
+//
+//	Version
+//	2019 R2   Initial version
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+/*
+ * Open Source PowerBuilder Foundation Class Libraries
+ *
+ * Copyright (c) 2004-2017, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted in accordance with the MIT License
+
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals and was originally based on software copyright (c) 
+ * 1996-2004 Sybase, Inc. http://www.sybase.com.  For more
+ * information on the Open Source PowerBuilder Foundation Class
+ * Libraries see https://github.com/OpenSourcePFCLibraries
+*/
+//
+//////////////////////////////////////////////////////////////////////////////
+
+powerobject	lpo_parent
+
+lpo_parent = this.GetParent()
+
+// Loop getting the parent of the object until it is of type window!
+do while IsValid (lpo_parent) 
+	if lpo_parent.TypeOf() <> window! then
+		lpo_parent = lpo_parent.GetParent()
+	else
+		exit
+	end if
+loop
+
+if IsNull(lpo_parent) Or not IsValid (lpo_parent) then
+	setnull(aw_parent)	
+	return -1
+end If
+
+aw_parent = lpo_parent
+return 1
+
+end function
+
+protected function integer of_messagebox (string as_id, string as_title, string as_text, icon ae_icon, button ae_button, integer ai_default);//////////////////////////////////////////////////////////////////////////////
+//
+//	Function:  			of_MessageBox
+//
+//	Access:  			protected
+//
+//	Arguments:
+//	as_id			An ID for the Message.
+//	as_title  	Text for title bar
+//	as_text		Text for the actual message.
+//	ae_icon 		The icon you want to display on the MessageBox.
+//	ae_button	Set of CommandButtons you want to display on the MessageBox.
+//	ai_default  The default button.
+//
+//	Returns:  integer
+//	Return value of the MessageBox.
+//
+//	Description:
+//	Display a PowerScript MessageBox.  
+//	Allow PFC MessageBoxes to be manipulated prior to their actual display.
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Revision History
+//
+//	Version
+//	2019 R2   Initial version
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+/*
+ * Open Source PowerBuilder Foundation Class Libraries
+ *
+ * Copyright (c) 2004-2017, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted in accordance with the MIT License
+
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals and was originally based on software copyright (c) 
+ * 1996-2004 Sybase, Inc. http://www.sybase.com.  For more
+ * information on the Open Source PowerBuilder Foundation Class
+ * Libraries see https://github.com/OpenSourcePFCLibraries
+*/
+//
+//////////////////////////////////////////////////////////////////////////////
+
+Return MessageBox(as_title, as_text, ae_icon, ae_button, ai_default)
+end function
+
+on pfc_u_rbb.create
+end on
+
+on pfc_u_rbb.destroy
+end on
+

--- a/ws_objects/pfcmain/pfcmain.pbl.src/pfc_u_wb.sru
+++ b/ws_objects/pfcmain/pfcmain.pbl.src/pfc_u_wb.sru
@@ -1,0 +1,208 @@
+﻿$PBExportHeader$pfc_u_wb.sru
+$PBExportComments$PFC WebBrowser class
+forward
+global type pfc_u_wb from webbrowser
+end type
+end forward
+
+global type pfc_u_wb from webbrowser
+integer width = 343
+integer height = 352
+end type
+global pfc_u_wb pfc_u_wb
+
+type variables
+Protected:
+boolean		ib_IsObsolete
+end variables
+forward prototypes
+public function integer of_getparentwindow (ref window aw_parent)
+protected function integer of_messagebox (string as_id, string as_title, string as_text, icon ae_icon, button ae_button, integer ai_default)
+end prototypes
+
+public function integer of_getparentwindow (ref window aw_parent);//////////////////////////////////////////////////////////////////////////////
+//
+//	Function:  of_GetParentWindow
+//
+//	Access:  public
+//
+//	Arguments:
+//	aw_parent   The Parent window for this object (passed by reference).
+//	   If a parent window is not found, aw_parent is NULL
+//
+//	Returns:  integer
+//	 1 = success
+//	-1 = error
+//
+//	Description:	 Calculates the parent window of a window object
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Revision History
+//
+//	Version
+//	2019 R2   Initial version
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+/*
+ * Open Source PowerBuilder Foundation Class Libraries
+ *
+ * Copyright (c) 2004-2017, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted in accordance with the MIT License
+
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals and was originally based on software copyright (c) 
+ * 1996-2004 Sybase, Inc. http://www.sybase.com.  For more
+ * information on the Open Source PowerBuilder Foundation Class
+ * Libraries see https://github.com/OpenSourcePFCLibraries
+*/
+//
+//////////////////////////////////////////////////////////////////////////////
+
+powerobject	lpo_parent
+
+lpo_parent = this.GetParent()
+
+// Loop getting the parent of the object until it is of type window!
+do while IsValid (lpo_parent) 
+	if lpo_parent.TypeOf() <> window! then
+		lpo_parent = lpo_parent.GetParent()
+	else
+		exit
+	end if
+loop
+
+if IsNull(lpo_parent) Or not IsValid (lpo_parent) then
+	setnull(aw_parent)	
+	return -1
+end If
+
+aw_parent = lpo_parent
+return 1
+
+end function
+
+protected function integer of_messagebox (string as_id, string as_title, string as_text, icon ae_icon, button ae_button, integer ai_default);//////////////////////////////////////////////////////////////////////////////
+//
+//	Function:  			of_MessageBox
+//
+//	Access:  			protected
+//
+//	Arguments:
+//	as_id			An ID for the Message.
+//	as_title  	Text for title bar
+//	as_text		Text for the actual message.
+//	ae_icon 		The icon you want to display on the MessageBox.
+//	ae_button	Set of CommandButtons you want to display on the MessageBox.
+//	ai_default  The default button.
+//
+//	Returns:  integer
+//	Return value of the MessageBox.
+//
+//	Description:
+//	Display a PowerScript MessageBox.  
+//	Allow PFC MessageBoxes to be manipulated prior to their actual display.
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+//	Revision History
+//
+//	Version
+//	2019 R2   Initial version
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+/*
+ * Open Source PowerBuilder Foundation Class Libraries
+ *
+ * Copyright (c) 2004-2017, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted in accordance with the MIT License
+
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals and was originally based on software copyright (c) 
+ * 1996-2004 Sybase, Inc. http://www.sybase.com.  For more
+ * information on the Open Source PowerBuilder Foundation Class
+ * Libraries see https://github.com/OpenSourcePFCLibraries
+*/
+//
+//////////////////////////////////////////////////////////////////////////////
+
+Return MessageBox(as_title, as_text, ae_icon, ae_button, ai_default)
+end function
+
+on pfc_u_wb.create
+end on
+
+on pfc_u_wb.destroy
+end on
+
+event getfocus;//////////////////////////////////////////////////////////////////////////////
+//
+//	Event:  			getfocus
+//
+//	(Arguments:		None)
+//
+//	(Returns:  		None)
+//
+//	Description:	If appropriate, notify the parent window that this
+//						control got focus.
+//
+//////////////////////////////////////////////////////////////////////////////
+//	
+//	Revision History
+//
+//	Version
+//	2019 R2   Initial version
+//
+//////////////////////////////////////////////////////////////////////////////
+//
+/*
+ * Open Source PowerBuilder Foundation Class Libraries
+ *
+ * Copyright (c) 2004-2017, All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted in accordance with the MIT License
+
+ *
+ * https://opensource.org/licenses/MIT
+ *
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals and was originally based on software copyright (c) 
+ * 1996-2004 Sybase, Inc. http://www.sybase.com.  For more
+ * information on the Open Source PowerBuilder Foundation Class
+ * Libraries see https://github.com/OpenSourcePFCLibraries
+*/
+//
+//////////////////////////////////////////////////////////////////////////////
+
+window 	lw_parent
+
+//Check for microhelp requirements.
+If gnv_app.of_GetMicrohelp() Then
+	//Notify the parent.
+	of_GetParentWindow(lw_parent)
+	If IsValid(lw_parent) Then
+		lw_parent.Dynamic Event pfc_ControlGotFocus (this)
+	End If
+End If
+
+end event
+

--- a/ws_objects/pfemain/pfemain.pbl.src/u_rbb.sru
+++ b/ws_objects/pfemain/pfemain.pbl.src/u_rbb.sru
@@ -1,0 +1,19 @@
+﻿$PBExportHeader$u_rbb.sru
+$PBExportComments$Extension RibbonBar class
+forward
+global type u_rbb from pfc_u_rbb
+end type
+end forward
+
+global type u_rbb from pfc_u_rbb
+end type
+global u_rbb u_rbb
+
+on u_rbb.create
+call super::create
+end on
+
+on u_rbb.destroy
+call super::destroy
+end on
+

--- a/ws_objects/pfemain/pfemain.pbl.src/u_wb.sru
+++ b/ws_objects/pfemain/pfemain.pbl.src/u_wb.sru
@@ -1,0 +1,19 @@
+﻿$PBExportHeader$u_wb.sru
+$PBExportComments$Extension WebBrowser class
+forward
+global type u_wb from pfc_u_wb
+end type
+end forward
+
+global type u_wb from pfc_u_wb
+end type
+global u_wb u_wb
+
+on u_wb.create
+call super::create
+end on
+
+on u_wb.destroy
+call super::destroy
+end on
+


### PR DESCRIPTION
I have added base classes for WebBrowser and Ribbonbar control with base functions (of_getparentwindow and of_messagebox). Also implemented getfocus event for WebBrowser control.
Only usable with PB 2019 R2!