### PR TITLE
changes for pfc_n_cst_platform and pbdom objects

### DIFF
--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_attribute.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_attribute.sru
@@ -4,7 +4,7 @@ global type pbdom_attribute from pbdom_object
 end type
 end forward
 
-global type pbdom_attribute from pbdom_object native "PBDOM190.pbx"
+global type pbdom_attribute from pbdom_object native "PBDOM.pbx"
 public function  string			GetName()
 public function  string			GetText()
 public function  boolean			GetContent(ref pbdom_object pbdom_object_array[])

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_builder.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_builder.sru
@@ -4,7 +4,7 @@ global type pbdom_builder from nonvisualobject
 end type
 end forward
 
-global type pbdom_builder from nonvisualobject native "PBDOM190.pbx"
+global type pbdom_builder from nonvisualobject native "PBDOM.pbx"
 public function  pbdom_document BuildFromString(string strXMLString)
 public function  pbdom_document BuildFromDataStore(datastore datastore_ref)
 public function  pbdom_document BuildFromFile(string strURL)

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_cdata.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_cdata.sru
@@ -4,7 +4,7 @@ global type pbdom_cdata from pbdom_text
 end type
 end forward
 
-global type pbdom_cdata from pbdom_text native "PBDOM190.pbx"
+global type pbdom_cdata from pbdom_text native "PBDOM.pbx"
 public function  string				GetName()
 public function  string				GetText()
 public function  boolean				GetContent(ref pbdom_object pbdom_object_array[])

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_characterdata.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_characterdata.sru
@@ -4,7 +4,7 @@ global type pbdom_characterdata from pbdom_object
 end type
 end forward
 
-global type pbdom_characterdata from pbdom_object native "PBDOM190.pbx"
+global type pbdom_characterdata from pbdom_object native "PBDOM.pbx"
 public function  string				GetName()
 public function  string				GetText()
 public function  boolean				GetContent(ref pbdom_object pbdom_object_array[])

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_comment.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_comment.sru
@@ -4,7 +4,7 @@ global type pbdom_comment from pbdom_characterdata
 end type
 end forward
 
-global type pbdom_comment from pbdom_characterdata native "PBDOM190.pbx"
+global type pbdom_comment from pbdom_characterdata native "PBDOM.pbx"
 public function  string				GetName()
 public function  string				GetText()
 public function  boolean				GetContent(ref pbdom_object pbdom_object_array[])

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_doctype.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_doctype.sru
@@ -4,7 +4,7 @@ global type pbdom_doctype from pbdom_object
 end type
 end forward
 
-global type pbdom_doctype from pbdom_object native "PBDOM190.pbx"
+global type pbdom_doctype from pbdom_object native "PBDOM.pbx"
 public function  string			GetName()
 public function  string			GetText()
 public function  boolean			GetContent(ref pbdom_object pbdom_object_array[])

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_document.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_document.sru
@@ -4,7 +4,7 @@ global type pbdom_document from pbdom_object
 end type
 end forward
 
-global type pbdom_document from pbdom_object native "PBDOM190.pbx"
+global type pbdom_document from pbdom_object native "PBDOM.pbx"
 public function  string			GetName()
 public function  string			GetText()
 public function  boolean			GetContent(ref pbdom_object pbdom_object_array[])

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_element.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_element.sru
@@ -4,7 +4,7 @@ global type pbdom_element from pbdom_object
 end type
 end forward
 
-global type pbdom_element from pbdom_object native "PBDOM190.pbx"
+global type pbdom_element from pbdom_object native "PBDOM.pbx"
 public function  string			GetName()
 public function  string			GetText()
 public function  boolean			GetContent(ref pbdom_object pbdom_object_array[])

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_entityreference.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_entityreference.sru
@@ -4,7 +4,7 @@ global type pbdom_entityreference from pbdom_object
 end type
 end forward
 
-global type pbdom_entityreference from pbdom_object native "PBDOM190.pbx"
+global type pbdom_entityreference from pbdom_object native "PBDOM.pbx"
 public function  string				GetName()
 public function  string				GetText()
 public function  boolean				GetContent(ref pbdom_object pbdom_object_array[])

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_exception.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_exception.sru
@@ -4,7 +4,7 @@ global type pbdom_exception from exception
 end type
 end forward
 
-global type pbdom_exception from exception native "PBDOM190.pbx"
+global type pbdom_exception from exception native "PBDOM.pbx"
 public function  long				GetExceptionCode()
 end type
 global pbdom_exception pbdom_exception

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_object.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_object.sru
@@ -4,7 +4,7 @@ global type pbdom_object from nonvisualobject
 end type
 end forward
 
-global type pbdom_object from nonvisualobject native "PBDOM190.pbx"
+global type pbdom_object from nonvisualobject native "PBDOM.pbx"
 public function  string			GetName()
 public function  string			GetText()
 public function  boolean			GetContent(ref pbdom_object pbdom_object_array[])

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_processinginstruction.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_processinginstruction.sru
@@ -4,7 +4,7 @@ global type pbdom_processinginstruction from pbdom_object
 end type
 end forward
 
-global type pbdom_processinginstruction from pbdom_object native "PBDOM190.pbx"
+global type pbdom_processinginstruction from pbdom_object native "PBDOM.pbx"
 public function  string			GetName()
 public function  string			GetText()
 public function  boolean			GetContent(ref pbdom_object pbdom_object_array[])

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_text.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pbdom_text.sru
@@ -4,7 +4,7 @@ global type pbdom_text from pbdom_characterdata
 end type
 end forward
 
-global type pbdom_text from pbdom_characterdata native "PBDOM190.pbx"
+global type pbdom_text from pbdom_characterdata native "PBDOM.pbx"
 public function  string				GetName()
 public function  string				GetText()
 public function  boolean				GetContent(ref pbdom_object pbdom_object_array[])


### PR DESCRIPTION
As far as the pbdom objects are concerned:
**I'd rather not see the pbdom objects at all in the pfcs.** 
There might be different versions of PBDOM.pbx and also there seem to be different versions for 32 and 64 bit. 
I've adapted them to use pbdom.pbx instead of pbdom190.pbx (by simply importing the latest 32 bit PBDOM.pbx version on top of them), but once again: I'd rather not see them at all in pfcs.
- Users can import the pbx themselves after all.
- What I don't know is whether there might be some dependency created by someone in the pfcs?