### PR TITLE
pfc_n_cst_measureconversion issue.

### DIFF
--- a/PFC.pbw
+++ b/PFC.pbw
@@ -9,5 +9,5 @@ Save Format v3.0(19990112)
  4 "security\\pfcsecsc\\security scanner.pbt";
  5 "examples\\appexamp\\pfc examples.pbt";
 @end;
-DefaultTarget "examples\\appexamp\\pfc examples.pbt";
-DefaultRemoteTarget "examples\\appexamp\\pfc examples.pbt";
+DefaultTarget "pfcapp\\generic_pfc_app.pbt";
+DefaultRemoteTarget "pfcapp\\generic_pfc_app.pbt";

--- a/ws_objects/demoapp/peat.pbl.src/peat.sra
+++ b/ws_objects/demoapp/peat.pbl.src/peat.sra
@@ -14,7 +14,8 @@ n_cst_peat	 gnv_app
 end variables
 
 global type peat from application
- end type
+ string appruntimeversion = "19.2.0.2703"
+end type
 global peat peat
 
 on peat.create

--- a/ws_objects/examples/appexamp/appexamp.pbl.src/pfcexamp.sra
+++ b/ws_objects/examples/appexamp/appexamp.pbl.src/pfcexamp.sra
@@ -12,7 +12,8 @@ n_ExampleAppManager gnv_app
 end variables
 
 global type pfcexamp from application
- end type
+ string appruntimeversion = "19.2.0.2703"
+end type
 global pfcexamp pfcexamp
 
 on pfcexamp.create

--- a/ws_objects/examples/appexmdw/appexmdw.pbl.src/d_objects.srd
+++ b/ws_objects/examples/appexmdw/appexmdw.pbl.src/d_objects.srd
@@ -1,0 +1,12 @@
+﻿$PBExportHeader$d_objects.srd
+$PBExportComments$List of xref objects ( w_TreeViewRecursive )
+release 5;
+datawindow(units=0 timer_interval=0 color=79219928 processing=1 print.documentname="" print.orientation = 0 print.margin.left = 107 print.margin.right = 107 print.margin.top = 97 print.margin.bottom = 97 print.paper.source = 0 print.paper.size = 0 print.prompt=no grid.lines=0 selected.mouse=no )
+header(height=1 color="536870912" )
+summary(height=5 color="536870912" )
+footer(height=1 color="536870912" )
+detail(height=85 color="536870912" )
+table(column=(type=char(128) update=yes updatewhereclause=yes key=yes name=object_ref dbname="xref_info.object_ref" )
+ retrieve="PBSELECT( VERSION(400) DISTINCT ()TABLE(NAME=~"xref_info~" ) COLUMN(NAME=~"xref_info.object_ref~")WHERE(    EXP1 =~"~~~"xref_info~~~".~~~"object_ref~~~"~"   OP =~"like~"    EXP2 =~"'of_%'~" ) ) ORDER(NAME=~"xref_info.object_ref~" ASC=yes ) " update="xref_info" updatewhere=0 updatekeyinplace=no )
+text(band=header alignment="0" text="Object Ref"border="0" color="0" x="10" y="4" height="77" width="1029"  font.face="Arial" font.height="-12" font.weight="400"  font.family="2" font.pitch="2" font.charset="0" background.mode="2" background.color="16777215" )
+column(band=detail id=1 alignment="0" tabsequence=32766 border="5" color="0" x="10" y="0" height="77" width="1029" format="[general]"  name=object_ref edit.limit=0 edit.case=any edit.autoselect=yes  font.face="MS Sans Serif" font.height="-8" font.weight="400"  font.family="2" font.pitch="2" font.charset="0" background.mode="2" background.color="77633680" )

--- a/ws_objects/examples/appexmdw/appexmdw.pbl.src/d_objectsref.srd
+++ b/ws_objects/examples/appexmdw/appexmdw.pbl.src/d_objectsref.srd
@@ -1,0 +1,12 @@
+﻿$PBExportHeader$d_objectsref.srd
+$PBExportComments$List of xref objects referenced by another ( w_TreeViewRecursive )
+release 5;
+datawindow(units=0 timer_interval=0 color=79219928 processing=1 print.documentname="" print.orientation = 0 print.margin.left = 107 print.margin.right = 107 print.margin.top = 97 print.margin.bottom = 97 print.paper.source = 0 print.paper.size = 0 print.prompt=no grid.lines=0 selected.mouse=no )
+header(height=1 color="536870912" )
+summary(height=5 color="536870912" )
+footer(height=1 color="536870912" )
+detail(height=89 color="536870912" )
+table(column=(type=char(128) update=yes updatewhereclause=yes key=yes name=referenced_in dbname="xref_info.referenced_in" )
+ retrieve="PBSELECT( VERSION(400) DISTINCT ()TABLE(NAME=~"xref_info~" ) COLUMN(NAME=~"xref_info.referenced_in~")WHERE(    EXP1 =~"( ~~~"xref_info~~~".~~~"object_ref~~~"~"   OP =~"=~"    EXP2 =~":object )~" ) ) ORDER(NAME=~"xref_info.referenced_in~" ASC=yes ) ARG(NAME = ~"object~" TYPE = string) " update="xref_info" updatewhere=0 updatekeyinplace=no arguments=(("object", string)) )
+text(band=header alignment="0" text="Referenced In"border="0" color="0" x="10" y="4" height="77" width="1038"  font.face="Arial" font.height="-12" font.weight="400"  font.family="2" font.pitch="2" font.charset="0" background.mode="2" background.color="16777215" )
+column(band=detail id=1 alignment="0" tabsequence=32766 border="5" color="0" x="10" y="0" height="77" width="1038" format="[general]"  name=referenced_in edit.limit=0 edit.case=any edit.autoselect=yes  font.face="MS Sans Serif" font.height="-8" font.weight="400"  font.family="2" font.pitch="2" font.charset="0" background.mode="2" background.color="77633680" )

--- a/ws_objects/pfcapp/pfcapp.pbl.src/generic_pfc_app.sra
+++ b/ws_objects/pfcapp/pfcapp.pbl.src/generic_pfc_app.sra
@@ -13,7 +13,8 @@ global variables
 n_cst_appmanager gnv_app 
 end variables
 global type generic_pfc_app from application
- end type
+ string appruntimeversion = "19.2.0.2703"
+end type
 global generic_pfc_app generic_pfc_app
 
 on generic_pfc_app.create

--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pfc_n_cst_measureconversion.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pfc_n_cst_measureconversion.sru
@@ -5,9 +5,8 @@ global type pfc_n_cst_measureconversion from n_base
 end type
 end forward
 
-global type pfc_n_cst_measureconversion from n_base
+global type pfc_n_cst_measureconversion from n_base autoinstantiate
 end type
-global pfc_n_cst_measureconversion pfc_n_cst_measureconversion
 
 type variables
 

--- a/ws_objects/security/pfcsecad/pfcsecad.pbl.src/pfcsecurity_admin.sra
+++ b/ws_objects/security/pfcsecad/pfcsecad.pbl.src/pfcsecurity_admin.sra
@@ -14,7 +14,8 @@ n_pfcsecurity_appmanager gnv_app
 end variables
 
 global type pfcsecurity_admin from application
- end type
+ string appruntimeversion = "19.2.0.2703"
+end type
 global pfcsecurity_admin pfcsecurity_admin
 
 on pfcsecurity_admin.create

--- a/ws_objects/security/pfcsecsc/pfcsecsc.pbl.src/pfcsecurity_scanner.sra
+++ b/ws_objects/security/pfcsecsc/pfcsecsc.pbl.src/pfcsecurity_scanner.sra
@@ -17,6 +17,7 @@ end variables
 
 global type pfcsecurity_scanner from application
 string appname = "pfcsecurity_scanner"
+string appruntimeversion = "19.2.0.2703"
 end type
 global pfcsecurity_scanner pfcsecurity_scanner
 

--- a/ws_objects/tutorial/pfctutor.pbl.src/pfctutor.sra
+++ b/ws_objects/tutorial/pfctutor.pbl.src/pfctutor.sra
@@ -14,7 +14,8 @@ n_cst_appmanager   gnv_app
 end variables
 
 global type pfctutor from application
- end type
+ string appruntimeversion = "19.2.0.2703"
+end type
 global pfctutor pfctutor
 
 on pfctutor.create


### PR DESCRIPTION
Changes in first commit have to do with runtime change. Those are not really required. But now that this information is stored in application object, we should have some guidelines about how to treat that change.

In second commit I believe that pfc_n_cst_measureconversion in pfcapsrv.pbl should be marked to be autoinstatiated. This object is used in pfc_n_cst_pbunitconversion. But nowhere in this object pfc_n_cst_measureconversion (invo_measurementConversion) is created or destroyed. In many accasions pfc_n_cst_pbunitconversion calls functions declared in pfc_n_cst_measureconversion. Actually pfc_n_cst_measureconversion doesn't have anything except from object functions doing unit conversions.

In our case, we had an issue with sort service in datawindow (based on column header). In latest pfcs it puts an arrow in the column used to sort data, showing if it's an ascending or descending sort. In some cases some functions are used to calculate the position to place that symbol. As the object is not instantiated the application will crash at this point, 