### PR TITLE
I believe that pfc_n_cst_measureconversion in pfcapsrv.pbl should be …

### DIFF
--- a/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pfc_n_cst_measureconversion.sru
+++ b/ws_objects/pfcapsrv/pfcapsrv.pbl.src/pfc_n_cst_measureconversion.sru
@@ -5,9 +5,8 @@ global type pfc_n_cst_measureconversion from n_base
 end type
 end forward
 
-global type pfc_n_cst_measureconversion from n_base
+global type pfc_n_cst_measureconversion from n_base autoinstantiate
 end type
-global pfc_n_cst_measureconversion pfc_n_cst_measureconversion
 
 type variables
 


### PR DESCRIPTION
I believe that pfc_n_cst_measureconversion in pfcapsrv.pbl should be marked to be autoinstatiated. This object is used in pfc_n_cst_pbunitconversion. But nowhere in this object pfc_n_cst_measureconversion (invo_measurementConversion) is created or destroyed. In many accasions pfc_n_cst_pbunitconversion calls functions declared in pfc_n_cst_measureconversion. Actually pfc_n_cst_measureconversion doesn't have anything except from object functions doing unit conversions.

In our case, we had an issue with sort service in datawindow (based on column header). In latest pfcs it puts an arrow in the column used to sort data, showing if it's an ascending or descending sort. In some cases some functions are used to calculate the position to place that symbol. As the object is not instantiated the application will crash at this point,